### PR TITLE
Assign Role instead of Sync

### DIFF
--- a/src/Http/Middleware/HasCrmAccess.php
+++ b/src/Http/Middleware/HasCrmAccess.php
@@ -24,7 +24,7 @@ class HasCrmAccess
         }
        
         if (config('laravel-crm.crm_owner') == auth()->user()->email && (! auth()->user()->hasRole('Owner') || ! auth()->user()->hasCrmAccess())) {
-            auth()->user()->syncRoles(['Owner']);
+            auth()->user()->assignRole('Owner');
 
             auth()->user()->forceFill([
                 'crm_access' => 1,


### PR DESCRIPTION
This will prevent it breaking apps that are already using spatie/permissions.

`syncRoles()` detaches all previous roles, so the "owner" loses all their previously held permissions (via roles)!