### PR TITLE
--Fix for #83 - Error filtering leads - Looking for labels.id instead of crm_labels.id bug Something isn't working

### DIFF
--- a/src/Livewire/Deals/DealBoard.php
+++ b/src/Livewire/Deals/DealBoard.php
@@ -106,7 +106,7 @@ class DealBoard extends KanbanBoard
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy('pipeline_stage_order')
             ->oldest()
             ->get();

--- a/src/Livewire/Deals/DealIndex.php
+++ b/src/Livewire/Deals/DealIndex.php
@@ -117,7 +117,7 @@ class DealIndex extends Component
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Deliveries/DeliveryIndex.php
+++ b/src/Livewire/Deliveries/DeliveryIndex.php
@@ -100,7 +100,7 @@ class DeliveryIndex extends Component
     public function deliveries(): LengthAwarePaginator
     {
         return Delivery::when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Invoices/InvoiceIndex.php
+++ b/src/Livewire/Invoices/InvoiceIndex.php
@@ -122,7 +122,7 @@ class InvoiceIndex extends Component
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Leads/LeadBoard.php
+++ b/src/Livewire/Leads/LeadBoard.php
@@ -104,7 +104,7 @@ class LeadBoard extends KanbanBoard
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy('pipeline_stage_order')
             ->oldest()
             ->get();

--- a/src/Livewire/Leads/LeadIndex.php
+++ b/src/Livewire/Leads/LeadIndex.php
@@ -115,7 +115,7 @@ class LeadIndex extends Component
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->when($this->lead_source_id, fn (Builder $q) => $q->whereIn('lead_source_id', $this->lead_source_id))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);

--- a/src/Livewire/Orders/OrderIndex.php
+++ b/src/Livewire/Orders/OrderIndex.php
@@ -119,7 +119,7 @@ class OrderIndex extends Component
                     }
                 });
             })->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Organizations/OrganizationIndex.php
+++ b/src/Livewire/Organizations/OrganizationIndex.php
@@ -76,7 +76,7 @@ class OrganizationIndex extends Component
                 $q->where('name', 'like', "%$this->search%");
             }
         })->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/People/PersonIndex.php
+++ b/src/Livewire/People/PersonIndex.php
@@ -84,7 +84,7 @@ class PersonIndex extends Component
                 });
             }
         })->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Products/ProductIndex.php
+++ b/src/Livewire/Products/ProductIndex.php
@@ -81,7 +81,7 @@ class ProductIndex extends Component
         return Product::when($this->search, function (Builder $q) {
             $q->where('name', 'like', "%$this->search%");
         })->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/PurchaseOrders/PurchaseOrderIndex.php
+++ b/src/Livewire/PurchaseOrders/PurchaseOrderIndex.php
@@ -117,7 +117,7 @@ class PurchaseOrderIndex extends Component
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Quotes/QuoteBoard.php
+++ b/src/Livewire/Quotes/QuoteBoard.php
@@ -106,7 +106,7 @@ class QuoteBoard extends KanbanBoard
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy('pipeline_stage_order')
             ->oldest()
             ->get();

--- a/src/Livewire/Quotes/QuoteIndex.php
+++ b/src/Livewire/Quotes/QuoteIndex.php
@@ -119,7 +119,7 @@ class QuoteIndex extends Component
                 });
             })
             ->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy($sortColumn, $sortDirection)
             ->paginate(25);
     }

--- a/src/Livewire/Teams/TeamIndex.php
+++ b/src/Livewire/Teams/TeamIndex.php
@@ -65,7 +65,7 @@ class TeamIndex extends Component
         return Team::when($this->search, function (Builder $q) {
             $q->where('name', 'like', "%$this->search%");
         })->when($this->user_id, fn (Builder $q) => $q->whereIn('team_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }

--- a/src/Livewire/Users/UserIndex.php
+++ b/src/Livewire/Users/UserIndex.php
@@ -75,7 +75,7 @@ class UserIndex extends Component
         return User::when($this->search, function (Builder $q) {
             $q->where('name', 'like', "%$this->search%");
         })->when($this->user_id, fn (Builder $q) => $q->whereIn('user_owner_id', $this->user_id))
-            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn('labels.id', $this->label_id)))
+            ->when($this->label_id, fn (Builder $q) => $q->whereHas('labels', fn (Builder $q) => $q->whereIn(config('laravel-crm.db_table_prefix').'labels.id', $this->label_id)))
             ->orderBy(...array_values($this->sortBy))
             ->paginate(25);
     }


### PR DESCRIPTION
Globally replaced references to 'labels.id' in Eloquent queries with config('laravel-crm.db_table_prefix').'labels.id'.  The fix tested successfully.